### PR TITLE
Customize optimization

### DIFF
--- a/ams/core/service.py
+++ b/ams/core/service.py
@@ -97,6 +97,21 @@ class RBaseService(BaseService):
 class ValueService(RBaseService):
     """
     Service to store given numeric values.
+
+    Parameters
+    ----------
+    name : str, optional
+        Instance name.
+    tex_name : str, optional
+        TeX name.
+    unit : str, optional
+        Unit.
+    info : str, optional
+        Description.
+    vtype : Type, optional
+        Variable type.
+    model : str, optional
+        Model name.
     """
 
     def __init__(self,

--- a/ams/core/service.py
+++ b/ams/core/service.py
@@ -94,6 +94,32 @@ class RBaseService(BaseService):
             return f'{self.class_name}: {self.rtn.class_name}.{self.name}'
 
 
+class ValueService(RBaseService):
+    """
+    Service to store given numeric values.
+    """
+
+    def __init__(self,
+                 name: str,
+                 value: np.ndarray,
+                 tex_name: str = None,
+                 unit: str = None,
+                 info: str = None,
+                 vtype: Type = None,
+                 model: str = None,
+                 ):
+        super().__init__(name=name, tex_name=tex_name, unit=unit,
+                         info=info, vtype=vtype, model=model)
+        self._v = value
+
+    @property
+    def v(self):
+        """
+        Value of the service.
+        """
+        return self._v
+
+
 class ROperationService(RBaseService):
     """
     Base calss for operational services used in routine.

--- a/ams/models/renewable/regcv1.py
+++ b/ams/models/renewable/regcv1.py
@@ -32,7 +32,10 @@ class REGCV1(ModelData, Model):
         self.gen = IdxParam(info="static generator index",
                             mandatory=True,
                             )
-
+        self.Sn = NumParam(default=100.0, tex_name='S_n',
+                           info='device MVA rating',
+                           unit='MVA',
+                           )
         self.gammap = NumParam(default=1.0,
                                info="P ratio of linked static gen",
                                tex_name=r'\gamma_P'

--- a/ams/models/renewable/regcv1.py
+++ b/ams/models/renewable/regcv1.py
@@ -32,3 +32,12 @@ class REGCV1(ModelData, Model):
         self.gen = IdxParam(info="static generator index",
                             mandatory=True,
                             )
+
+        self.gammap = NumParam(default=1.0,
+                               info="P ratio of linked static gen",
+                               tex_name=r'\gamma_P'
+                               )
+        self.gammaq = NumParam(default=1.0,
+                               info="Q ratio of linked static gen",
+                               tex_name=r'\gamma_Q'
+                               )

--- a/ams/routines/dcopf.py
+++ b/ams/routines/dcopf.py
@@ -150,7 +150,9 @@ class DCOPFBase(RoutineModel):
                 # NOTE: only unpack the variables that are in the model or group
                 try:
                     var.owner.set(src=var.src, attr='v', idx=idx, value=var.v)
-                except KeyError:
+                except KeyError:  # failed to find source var in the owner (model or group)
+                    pass
+                except TypeError:  # failed to find source var in the owner (model or group)
                     pass
         self.system.recent = self.system.routines[self.class_name]
         return True

--- a/ams/routines/dopf.py
+++ b/ams/routines/dopf.py
@@ -136,12 +136,12 @@ class DOPF2Data(DOPFData):
 
     def __init__(self):
         DOPFData.__init__(self)
-        self.cm = RParam(info='RegUp reserve coefficient',
+        self.cm = RParam(info='Virtual inertia cost',
                          name='cm', src='cm',
                          tex_name=r'c_{m}', unit=r'$/s',
                          model='REGCV1Cost',
                          indexer='reg', imodel='REGCV1')
-        self.cd = RParam(info='RegDown reserve coefficient',
+        self.cd = RParam(info='Virtual damping cost',
                          name='cd', src='cd',
                          tex_name=r'c_{d}', unit=r'$/(p.u.)',
                          model='REGCV1Cost',

--- a/ams/routines/routine.py
+++ b/ams/routines/routine.py
@@ -3,7 +3,7 @@ Module for routine data.
 """
 
 import logging  # NOQA
-from typing import Optional, Union  # NOQA
+from typing import Optional, Union, Type  # NOQA
 from collections import OrderedDict  # NOQA
 
 import numpy as np  # NOQA
@@ -17,7 +17,7 @@ from ams.opt.omodel import OModel, Var, Constraint, Objective  # NOQA
 
 from ams.core.symprocessor import SymProcessor  # NOQA
 from ams.core.documenter import RDocumenter  # NOQA
-from ams.core.service import RBaseService  # NOQA
+from ams.core.service import RBaseService, ValueService  # NOQA
 
 from ams.models.group import GroupBase  # NOQA
 from ams.core.model import Model  # NOQA
@@ -411,6 +411,26 @@ class RoutineModel:
         self.is_setup = False
         self.exec_time = 0.0
         self.exit_code = 0
+
+    def addService(self,
+                   name: str,
+                   value: np.ndarray,
+                   tex_name: str = None,
+                   unit: str = None,
+                   info: str = None,
+                   vtype: Type = None,
+                   model: str = None,):
+        """
+        Add numerical service to the routine.
+        """
+        item = ValueService(name=name, value=value, tex_name=tex_name, unit=unit,
+                            info=info, vtype=vtype, model=model)
+        # add the service as an routine attribute
+        setattr(self, name, item)
+
+        self._post_add_check()
+
+        return True
 
     def addConstrs(self,
                    name: str,

--- a/ams/routines/routine.py
+++ b/ams/routines/routine.py
@@ -3,6 +3,7 @@ Module for routine data.
 """
 
 import logging  # NOQA
+from typing import Optional, Union  # NOQA
 from collections import OrderedDict  # NOQA
 
 import numpy as np  # NOQA
@@ -402,3 +403,149 @@ class RoutineModel:
             return True
 
         logger.warning(f"Constraint <{name}> not found.")
+
+    def _post_add_check(self):
+        """
+        Post-addition check.
+        """
+        self.is_setup = False
+        self.exec_time = 0.0
+        self.exit_code = 0
+
+    def addConstrs(self,
+                   name: str,
+                   e_str: str,
+                   info: Optional[str] = None,
+                   type: Optional[str] = 'uq',
+                   ):
+        """
+        Add a constraint to the routine.
+
+        Parameters
+        ----------
+        name : str
+            Constraint name. One should typically assigning the name directly because
+            it will be automatically assigned by the model. The value of ``name``
+            will be the symbol name to be used in expressions.
+        e_str : str
+            Constraint expression string.
+        info : str, optional
+            Descriptive information
+        type : str, optional
+            Constraint type, ``uq`` for uncertain, ``eq`` for equality, ``ineq`` for inequality.
+
+        """
+        item = Constraint(name=name, e_str=e_str, info=info, type=type)
+        # add the constraint as an routine attribute
+        setattr(self, name, item)
+
+        self._post_add_check()
+
+        return True
+
+    def addVars(self,
+                name: str,
+                model: Optional[str] = None,
+                shape: Optional[Union[int, tuple]] = None,
+                tex_name: Optional[str] = None,
+                info: Optional[str] = None,
+                src: Optional[str] = None,
+                unit: Optional[str] = None,
+                lb: Optional[str] = None,
+                ub: Optional[str] = None,
+                horizon: Optional[RParam] = None,
+                nonneg: Optional[bool] = False,
+                nonpos: Optional[bool] = False,
+                complex: Optional[bool] = False,
+                imag: Optional[bool] = False,
+                symmetric: Optional[bool] = False,
+                diag: Optional[bool] = False,
+                psd: Optional[bool] = False,
+                nsd: Optional[bool] = False,
+                hermitian: Optional[bool] = False,
+                bool: Optional[bool] = False,
+                integer: Optional[bool] = False,
+                pos: Optional[bool] = False,
+                neg: Optional[bool] = False,):
+        """
+        Add a variable to the routine.
+
+        Parameters
+        ----------
+        name : str, optional
+            Variable name. One should typically assigning the name directly because
+            it will be automatically assigned by the model. The value of ``name``
+            will be the symbol name to be used in expressions.
+        model : str, optional
+            Name of the owner model or group.
+        shape : int or tuple, optional
+            Shape of the variable. If is None, the shape of `model` will be used.
+        info : str, optional
+            Descriptive information
+        unit : str, optional
+            Unit
+        tex_name : str
+            LaTeX-formatted variable symbol. If is None, the value of `name` will be
+            used.
+        src : str, optional
+            Source variable name. If is None, the value of `name` will be used.
+        lb : str, optional
+            Lower bound
+        ub : str, optional
+            Upper bound
+        horizon : ams.routines.RParam, optional
+            Horizon idx.
+        nonneg : bool, optional
+            Non-negative variable
+        nonpos : bool, optional
+            Non-positive variable
+        complex : bool, optional
+            Complex variable
+        imag : bool, optional
+            Imaginary variable
+        symmetric : bool, optional
+            Symmetric variable
+        diag : bool, optional
+            Diagonal variable
+        psd : bool, optional
+            Positive semi-definite variable
+        nsd : bool, optional
+            Negative semi-definite variable
+        hermitian : bool, optional
+            Hermitian variable
+        bool : bool, optional
+            Boolean variable
+        integer : bool, optional
+            Integer variable
+        pos : bool, optional
+            Positive variable
+        neg : bool, optional
+            Negative variable
+
+        """
+        if model is None and shape is None:
+            raise ValueError("Either model or shape must be specified.")
+        item = Var(name=name, tex_name=tex_name, info=info, src=src, unit=unit,
+                   model=model, shape=shape, lb=lb, ub=ub, horizon=horizon, nonneg=nonneg,
+                   nonpos=nonpos, complex=complex, imag=imag, symmetric=symmetric,
+                   diag=diag, psd=psd, nsd=nsd, hermitian=hermitian, bool=bool,
+                   integer=integer, pos=pos, neg=neg, )
+
+        # add the variable as an routine attribute
+        setattr(self, name, item)
+
+        # check variable owner validity if given
+        if model is not None:
+            if item.model in self.system.groups.keys():
+                item.is_group = True
+                item.owner = self.system.groups[item.model]
+            elif item.model in self.system.models.keys():
+                item.owner = self.system.models[item.model]
+            else:
+                msg = f'Model indicator \'{item.model}\' of <{item.rtn.class_name}.{name}>'
+                msg += f' is not a model or group. Likely a modeling error.'
+                logger.warning(msg)
+
+        self._post_add_check()
+
+        return True

--- a/ams/system.py
+++ b/ams/system.py
@@ -414,8 +414,8 @@ class System(andes_System):
             self.exit_code += 1
 
         a0 = 0
-        for mname, mdl in self.models.items():
-            for aname, algeb in mdl.algebs.items():
+        for _, mdl in self.models.items():
+            for _, algeb in mdl.algebs.items():
                 algeb.v = np.zeros(algeb.owner.n)
                 algeb.a = np.arange(a0, a0 + algeb.owner.n)
                 a0 += algeb.owner.n
@@ -428,8 +428,6 @@ class System(andes_System):
         gen_bus = self.StaticGen.get(src='bus', attr='v',
                                      idx=self.StaticGen.get_idx())
         all_bus = self.Bus.idx.v
-        regBus = [int(bus) if isinstance(bus, (int, float)) else bus for bus in gen_bus]
-        redBus = [int(bus) if isinstance(bus, (int, float)) else bus for bus in all_bus if bus not in gen_bus]
 
         # Restrucrue PQ load value to match gen bus pattern
 
@@ -452,10 +450,10 @@ class System(andes_System):
         ])
 
         # NOTE: initialize om for all routines
-        for rtnname, rtn in self.routines.items():
+        for _, rtn in self.routines.items():
             # rtn.setup()  # not setup optimization model in system setup stage
             a0 = 0
-            for vname, var in rtn.vars.items():
+            for _, var in rtn.vars.items():
                 var.a = np.arange(a0, a0 + var.owner.n)
                 a0 += var.owner.n
             for rpname, rparam in rtn.rparams.items():

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -9,6 +9,12 @@ The APIs before v3.0.0 are in beta and may change without prior notice.
 Pre-v1.0.0
 ==========
 
+v0.6.8 (2023-09-xx)
+-------------------
+
+- Add interfaces for customizing optimization models
+- Add model ``REGCV1`` and ``REGCV1Cost`` for virtual inertia scheduling
+
 v0.6.7 (2023-08-02)
 -------------------
 


### PR DESCRIPTION
Enable customizing optimization with newly added interfaces: ``addVars``, ``addService``, and ``addConstris``.

An example is excerpted below:
```python
import numpy as np
import ams

sp = ams.load(ams.get_case('ieee123/ieee123_regcv1.xlsx'),  setup=True,)

sp.LDOPF.addRParam(name='cm', src='cm',
                   info='Virtual inertia cost',
                   tex_name=r'c_{m}', unit=r'$/s',
                   model='REGCV1Cost', indexer='reg', imodel='REGCV1')
sp.LDOPF.addRParam(name='cd', src='cd',
                   info='Virtual damping cost',
                   tex_name=r'c_{m}', unit=r'$/s',
                   model='REGCV1Cost', indexer='reg', imodel='REGCV1')

sp.LDOPF.addVars(name='M', model='REGCV1', info='M decision')
sp.LDOPF.addVars(name='D', model='REGCV1', info='D decision')
sp.LDOPF.addVars(name='z', shape=(2,3), bool=True, info='M on/off')
sp.LDOPF.addService(name='zc', value=np.ones((3, 2)), info='M decision coefficient')
sp.LDOPF.addConstrs(name='vsgm', e_str='-zc@z', info='M decision coefficient')
sp.LDOPF.obj.e_str="sum(c2 * pg**2 + c1 * pg + ug * c0 + cm * M + cd * D)"

sp.LDOPF.setup()
```
